### PR TITLE
scrypt for client_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 pyramid_oauth2_provider README
-==================
+==============================
+
+
+##### Warning: 
+You will need to reset your DB tables related to this library and 
+provide a new ini config 'oauth2_provider.salt' when upgrading from v0.2.0.
+To reset the tables, run the init script with added boolean argument to drop:
+
+    initialize_pyramid_oauth2_provider_db-script.py development.ini true
+
 
 Getting Started
 ---------------
@@ -17,6 +26,16 @@ by doing the following:
   interface that works against your current user authentication check mechanism.
 * In your paster configuration configure which IAuthCheck implementation to use
   by specifying `oauth2_provider.auth_checker`.
+* In your production/development configuration, set a 16 random byte, base64 
+  encoded salt for scrypt:
+        
+        oauth2_provider.salt = REPLACEME
+        
+  How to generate a salt in Python:
+  
+        from base64 import b64encode
+        b64encode(os.urandom(16)).decode('utf-8')
+
 * In your development configuration, you may also want to disable ssl
   enforcement by specifying `oauth2_provider.require_ssl = false`.
 * Generate client credentials using the `create_client_credentials` script,

--- a/pyramid_oauth2_provider/scripts/initializedb.py
+++ b/pyramid_oauth2_provider/scripts/initializedb.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+import json
 
 from sqlalchemy import engine_from_config
 
@@ -27,16 +28,19 @@ from ..models import (
 
 def usage(argv):
     cmd = os.path.basename(argv[0])
-    print(('usage: %s <config_uri>\n'
-          '(example: "%s development.ini")' % (cmd, cmd))) 
+    print(('usage: %s <config_uri> <drop>\n'
+          '(example: "%s development.ini false")' % (cmd, cmd)))
     sys.exit(1)
 
 def main(argv=sys.argv):
-    if len(argv) != 2:
+    if len(argv) != 3:
         usage(argv)
     config_uri = argv[1]
+    drop = json.loads(argv[2].lower())
     setup_logging(config_uri)
     settings = get_appsettings(config_uri)
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
+    if drop:
+        Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+pyramid
+SQLAlchemy
+transaction
+pyramid_tm
+pyramid_debugtoolbar
+six==1.10.0
+zope.sqlalchemy
+zope.interface
+waitress
+cryptography

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requires = [
     'zope.sqlalchemy',
     'zope.interface',
     'waitress',
+    'cryptography'
     ]
 
 setup(name='pyramid_oauth2_provider',


### PR DESCRIPTION
Patch 1 for #16 - client_secret salting/hashing with scrypt (cryptography lib)

I removed all the other changes except for the DB column changes to Unicode, to avoid having to reset the DB tables twice. Once you merge this, I will submit the other patches incrementally.